### PR TITLE
Fix failing tests for subtract and Fahrenheit conversion, add multiply test (Closes #1)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,46 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest pytest-cov
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest --cov-report "xml:coverage.xml" --cov=.
+    - name: Create Coverage
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: orgoro/coverage@v3
+      with:
+          coverageFile: coverage.xml
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Compiled files
+*.pyc
+
+# Folders
+.pytest_cache
+__pycache__/

--- a/functions.py
+++ b/functions.py
@@ -3,7 +3,7 @@ def add(a, b):
 
 
 def subtract(a, b):
-    return a + b
+    return a - b
 
 
 def multiply(a, b):
@@ -11,4 +11,5 @@ def multiply(a, b):
 
 
 def convert_fahrenheit_to_celsius(fahrenheit):
-    return multiply(subtract(fahrenheit, 32), 9 / 5)
+    assert fahrenheit >= -459.67
+    return multiply(subtract(fahrenheit, 32), 5 / 9)

--- a/test_functions.py
+++ b/test_functions.py
@@ -8,12 +8,12 @@ def test_add():
     assert add("space", "ship") == "spaceship"
 
 
-# def test_subtract():
-#    assert subtract(3,2) == 1
+def test_subtract():
+   assert subtract(3,2) == 1
 
 
-# def test_convert_fahrenheit_to_celsius():
-#    assert f2c(32) == 0
-#    assert f2c(122) == pytest.approx(50)
-#    with pytest.raises(AssertionError):
-#        f2c(-600)
+def test_convert_fahrenheit_to_celsius():
+   assert f2c(32) == 0
+   assert f2c(122) == pytest.approx(50)
+   with pytest.raises(AssertionError):
+       f2c(-600)

--- a/test_functions.py
+++ b/test_functions.py
@@ -8,8 +8,14 @@ def test_add():
     assert add("space", "ship") == "spaceship"
 
 
+def test_multiply():
+    assert multiply(2, 3) == 6
+    assert multiply(2, -3) == -6
+    assert multiply('ha', 3) == 'hahaha'
+
+
 def test_subtract():
-   assert subtract(3,2) == 1
+   assert subtract(3, 2) == 1
 
 
 def test_convert_fahrenheit_to_celsius():


### PR DESCRIPTION
## Summary

Fix failing unit tests related to arithmetic functions and temperature conversion. Add missing unit test coverage for multiplication.

## Changes

* Corrected `subtract` implementation to return proper difference
* Fixed `convert_fahrenheit_to_celsius` logic and added validation for values below absolute zero
* Added unit tests for `multiply`

## Related Issue

Closes #1

## Testing

* All existing tests now pass
* Added new tests for `multiply`
* Verified edge case for invalid Fahrenheit input (below -459.67)

## Notes

* Validation ensures physically impossible temperatures raise an `AssertionError`
* Improves overall test coverage for arithmetic utilities
